### PR TITLE
http_port read as string and should be integer

### DIFF
--- a/server/GenerationServer.py
+++ b/server/GenerationServer.py
@@ -21,7 +21,7 @@ gsHandle = None
 class GenerationServer:
 
 	def __init__(self, hostname="", http_port=80, sqlite_path='/opt/dcept/var/honeytoken.db'):
-		http_port=int(http_port)
+		http_port = int(http_port)
 		server_class = BaseHTTPServer.HTTPServer
 		self.httpd = server_class((hostname, http_port), HttpHandler)
 		

--- a/server/GenerationServer.py
+++ b/server/GenerationServer.py
@@ -21,6 +21,7 @@ gsHandle = None
 class GenerationServer:
 
 	def __init__(self, hostname="", http_port=80, sqlite_path='/opt/dcept/var/honeytoken.db'):
+		http_port=int(http_port)
 		server_class = BaseHTTPServer.HTTPServer
 		self.httpd = server_class((hostname, http_port), HttpHandler)
 		


### PR DESCRIPTION
The current configuration seems to read dcept.cfg as a string and throw an error when removing the comment from the honeytoken_port variable. Casting the http_port variable to an int in GenerationServer fixes this situation.
